### PR TITLE
fix: not support in tsx file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ function transformSrcCode(
 ): string {
   const ast = parser.parse(code, {
     sourceType: 'module',
-    plugins: ['jsx'],
+    plugins: ['jsx', 'typescript'],
   });
   traverse(ast, {
     enter(path) {


### PR DESCRIPTION
fix: vite error: "'Const declarations' require an initialization value." when use tsx file extension in vue3-vite2.0 project
you can test in .tsx file