### PR TITLE
support for: import { Original as Alias } from 'Module'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ function transformSrcCode(
                 types.importDeclaration(
                   [
                     types.importDefaultSpecifier(
-                      types.identifier(importedName)
+                      types.identifier(spec.local.name)
                     ),
                   ],
                   types.stringLiteral(libPath)


### PR DESCRIPTION
the "Alias" part is contained in "local.name"